### PR TITLE
Bug/window resize take 2

### DIFF
--- a/shoes/native/gtk.c
+++ b/shoes/native/gtk.c
@@ -122,8 +122,11 @@ VALUE shoes_load_font(const char *filename) {
     {
       i++;
     }
-    if (i) 
+
+    if (i) {
       printf("removed %s %d times\n", filename, i);
+    }
+
     int fonts = AddFontResourceExA(filename, FR_PRIVATE, 0);
     if (fonts == 0) {
       printf("windows failed to add fonts in %s\n", filename);
@@ -210,16 +213,18 @@ VALUE shoes_font_list() {
 VALUE shoes_load_font(const char *filename) {
     FcConfig *fc = FcConfigGetCurrent();
     FcFontSet *fonts = FcFontSetCreate();
-    if (!FcFileScan(fonts, NULL, NULL, NULL, (const FcChar8 *)filename, FcTrue))
+    if (!FcFileScan(fonts, NULL, NULL, NULL, (const FcChar8 *)filename, FcTrue)) {
         return Qnil;
+    }
 
     VALUE ary = rb_ary_new();
     // should have a pango version below, eh?
     shoes_make_font_list(fonts, ary);
     FcFontSetDestroy(fonts);
 
-    if (!FcConfigAppFontAddFile(fc, (const FcChar8 *)filename))
+    if (!FcConfigAppFontAddFile(fc, (const FcChar8 *)filename)) {
         return Qnil;
+    }
 
     // refresh the FONTS list
     shoes_update_fonts(shoes_font_list());
@@ -249,8 +254,7 @@ shoes_gtk_app_startup(GApplication *application, gpointer user_data) {
 }
 
 gboolean
-shoes_gtk_app_cmdline (GApplication *application, gchar ***arguments,
-      gint *exit_status)
+shoes_gtk_app_cmdline (GApplication *application, gchar ***arguments, gint *exit_status)
 {
   /* This doesn't seem to work as documented.
    * *exit_status is 0x0 instead of a real pointer, arguments don't seem
@@ -269,9 +273,9 @@ GtkApplication *shoes_GtkApp;
 GtkCssProvider *shoes_css_provider = NULL; // user provided theme
 
 void shoes_gtk_css_error(GtkCssProvider *provider,
-               GtkCssSection  *section,
-               GError         *error,
-               gpointer        user_data) 
+                         GtkCssSection  *section,
+                         GError         *error,
+                         gpointer        user_data) 
 {
   fprintf(stderr,"%s\n", error->message);
 }
@@ -301,7 +305,9 @@ void shoes_gtk_load_css(shoes_settings *st) {
       fgets(ln, 59, df);
       // Trim \n from ln
       char *p = strrchr(ln, '\n');
-      if (p) *p = '\0';
+      if (p) {
+          *p = '\0';
+      }
       st->theme = rb_str_new2(ln);
       fclose(df);
       // now build the path to gtk.css
@@ -368,8 +374,9 @@ void shoes_native_init() {
 #ifdef SHOES_GTK_WIN32
        gdk_set_allowed_backends("win32,x11");
        // TODO: believe it or not - Gtk3.22.7 has a bug? on win10 
-       if (shoes_win10_gtk3_22_check())
-         shoes_gtk_backend = shoes_gtk_backend | WAYLAND;
+       if (shoes_win10_gtk3_22_check()) {
+            shoes_gtk_backend = shoes_gtk_backend | WAYLAND;
+       }
 #endif 
 #ifdef SHOES_QUARTZ
       gdk_set_allowed_backends("quartz,x11");
@@ -507,17 +514,20 @@ void shoes_native_slot_lengthen(SHOES_SLOT_OS *slot, int height, int endy) {
         if (gtk_adjustment_get_upper(adj) != (gdouble)endy) {
             gtk_range_set_range(GTK_RANGE(slot->vscroll), 0., (gdouble)endy);
 
-            if (gtk_adjustment_get_page_size(adj) >= gtk_adjustment_get_upper(adj))
+            if (gtk_adjustment_get_page_size(adj) >= gtk_adjustment_get_upper(adj)) {
                 gtk_widget_hide(slot->vscroll);
-            else
+            }
+            else {
                 gtk_widget_show(slot->vscroll);
+            }
         }
     }
 }
 
 void shoes_native_slot_scroll_top(SHOES_SLOT_OS *slot) {
-    if (slot->vscroll)
+    if (slot->vscroll) {
         gtk_range_set_value(GTK_RANGE(slot->vscroll), slot->scrolly);
+    }
 }
 
 int shoes_native_slot_gutter(SHOES_SLOT_OS *slot) {
@@ -526,11 +536,11 @@ int shoes_native_slot_gutter(SHOES_SLOT_OS *slot) {
         gtk_widget_get_preferred_size(slot->vscroll, NULL, &rnat);
         return rnat.width;
     }
+
     return 0;
 }
 
-void shoes_native_remove_item(SHOES_SLOT_OS *slot, VALUE item, char c) {
-}
+void shoes_native_remove_item(SHOES_SLOT_OS *slot, VALUE item, char c) {}
 
 //
 // Window-level events
@@ -550,8 +560,7 @@ static gboolean shoes_app_gtk_motion(GtkWidget *widget, GdkEventMotion *event, g
         if (event->state & GDK_CONTROL_MASK)
           mods = mods | SHOES_MODIFY_CTRL;
         int new_x, new_y;
-        gtk_widget_translate_coordinates(widget, app->slot->oscanvas, event->x, event->y,
-            &new_x, &new_y);
+        gtk_widget_translate_coordinates(widget, app->slot->oscanvas, event->x, event->y, &new_x, &new_y);
        if (app->have_menu) {
           shoes_app_motion(app, new_x, new_y + canvas->slot->scrolly, mods);
           //shoes_app_motion(app, (int)event->x, (int)event->y + canvas->slot->scrolly - app->mb_height, mods);
@@ -609,8 +618,7 @@ static gboolean shoes_app_gtk_button(GtkWidget *widget, GdkEventButton *event, g
       fprintf(stderr, "meta\n");   
 */
  		int new_x, new_y;
-		gtk_widget_translate_coordinates(widget, app->slot->oscanvas, event->x, event->y,
-			&new_x, &new_y);
+		gtk_widget_translate_coordinates(widget, app->slot->oscanvas, event->x, event->y, &new_x, &new_y);
     if (event->type == GDK_BUTTON_PRESS) {
       if (app->have_menu) {
         //shoes_app_click(app, event->button, event->x, event->y + canvas->slot->scrolly - app->mb_height, mods);
@@ -2017,16 +2025,20 @@ int shoes_win32_console() {
 int shoes_native_terminal() {
     // has a console been setup by --console flag?
     if (shoes_console_out == NULL) {
-        if (shoes_win32_console() == 0) // cshoes.exe can do this
+        if (shoes_win32_console() == 0) { // cshoes.exe can do this
             return 1;
+        }
     }
     // convert the (cached) FILE * for what ruby wants for fd[0], [1]...
-    if (dup2(_fileno(shoes_console_out), 1) == -1)
+    if (dup2(_fileno(shoes_console_out), 1) == -1) {
         printf("failed dup2 of stdout\n");
-    if (dup2(_fileno(shoes_console_out), 2) == -1)
+    }
+    if (dup2(_fileno(shoes_console_out), 2) == -1) {
         printf("failed dup2 of stderr\n");
-    if (dup2(_fileno(shoes_console_in), 0) == -1)
+    }
+    if (dup2(_fileno(shoes_console_in), 0) == -1) {
         printf("failed dup2 of stdin\n");
+    }
     printf("created win32 console\n");
     return 1;
 }
@@ -2144,8 +2156,9 @@ int shoes_native_monitor_get(shoes_app *app) {
   for (i = 0; i < cnt; i++) {
     GdkRectangle r;
     gdk_screen_get_monitor_geometry(screen, i,  &r);
-    if ((x >= r.x) && (x <= (r.x +r.width)) && (y >= r.y) && (y <= (r.y +r.height)))
-      return i;
+    if ((x >= r.x) && (x <= (r.x +r.width)) && (y >= r.y) && (y <= (r.y +r.height))) {
+        return i;
+    }
   }
   // should never get here, but if it does:
   return gdk_screen_get_primary_monitor(screen);
@@ -2177,16 +2190,19 @@ static void shoes_app_gtk_size_menu(GtkWidget *widget, cairo_t *cr, gpointer dat
     shoes_app *app = (shoes_app *)data;
     if (widget != app->os.window) {
       fprintf(stderr, "widget != app->os.window\n");
-      gtk_window_get_size(GTK_WINDOW(app->os.window), app->width, app->height);
+      gtk_window_get_size(GTK_WINDOW(app->os.window),  &app->width, &app->height);
     }
 #ifdef SZBUG
     fprintf(stderr,"shoes_app_gtk_size_menu: wid: %d hgt: %d\n", app->width, app->height);
 #endif
     app->height -= app->mb_height;
-    // trigger a resize & paint 
     
+    // trigger a resize & paint 
     GtkWidget *wdg = app->slot->oscanvas;
-    gtk_widget_set_size_request(&wdg, app->width, app->height);
+
+    if (wdg != NULL ) {
+       gtk_widget_set_size_request(GTK_WIDGET(wdg), -1, app->height);
+    }
     
     shoes_canvas_size(app->canvas, app->width, app->height);
 }
@@ -2206,21 +2222,21 @@ static void shoes_canvas_gtk_size_menu(GtkWidget *widget, GtkAllocation *size, g
             // && (size->height != canvas->slot->scrollh || size->width != canvas->slot->scrollw)) 
         if (size->height != canvas->slot->scrollh) {
           GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(canvas->slot->vscroll));
-          gtk_widget_set_size_request(canvas->slot->vscroll, -1, size->height);
+          gtk_widget_set_size_request(GTK_WIDGET(canvas->slot->vscroll), -1, size->height);
           
           //gtk_widget_set_size_request(GTK_CONTAINER(widget), canvas->app->width, size->height);
           GtkAllocation alloc;
-          gtk_widget_get_allocation((GtkWidget *)canvas->slot->vscroll, &alloc);  
+          gtk_widget_get_allocation(GTK_WIDGET (canvas->slot->vscroll), &alloc);  
 #ifdef SZBUG
           fprintf(stderr, "alloc: %d %d %d %d\n\n", alloc.x, alloc.y, alloc.width, alloc.height);
 #endif
-          gtk_fixed_move(GTK_FIXED(canvas->slot->oscanvas), canvas->slot->vscroll,
-                         size->width - alloc.width, 0);
+          gtk_fixed_move(GTK_FIXED(canvas->slot->oscanvas), GTK_WIDGET(canvas->slot->vscroll), size->width - alloc.width, 0);
           gtk_adjustment_set_page_size(adj, size->height);
           gtk_adjustment_set_page_increment(adj, size->height - 32);
   
-          if (gtk_adjustment_get_page_size(adj) >= gtk_adjustment_get_upper(adj))
+          if (gtk_adjustment_get_page_size(adj) >= gtk_adjustment_get_upper(adj)) {
               gtk_widget_hide(canvas->slot->vscroll);
+          }
           else {
               gtk_widget_show(canvas->slot->vscroll);
           }
@@ -2238,27 +2254,26 @@ static void shoes_canvas_gtk_size_menu(GtkWidget *widget, GtkAllocation *size, g
 gboolean shoes_app_gtk_configure_menu(GtkWidget *widget, GdkEvent *evt, gpointer data) {
   shoes_app *app = (shoes_app *)data;
   if (widget == app->os.window) {  // GtkWindow
-    gtk_window_resize(widget, evt->configure.width, evt->configure.height);
+    gtk_window_resize(GTK_WINDOW(widget), evt->configure.width, evt->configure.height);
     shoes_canvas *canvas;
     Data_Get_Struct(app->canvas, shoes_canvas, canvas);
 #if GTK_CHECK_VERSION(3,12,0)
-    if (gtk_window_is_maximized((GtkWindow *)widget)) {
+    if (gtk_window_is_maximized(GTK_WINDOW(widget)) {
 #else
     if (shoes_gtk_is_maximized(app, evt->configure.width, evt->configure.height)) {
 #endif
     //if (canvas->slot->vscroll && evt->configure.height != app->height) { 
           GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(canvas->slot->vscroll));
-          gtk_widget_set_size_request(canvas->slot->vscroll, -1, evt->configure.height);
+          gtk_widget_set_size_request(GTK_WIDGET(canvas->slot->vscroll), -1, evt->configure.height);
           
           GtkAllocation alloc;
-          gtk_widget_get_allocation((GtkWidget *)canvas->slot->vscroll, &alloc);  
+          gtk_widget_get_allocation(GTK_WIDGET(canvas->slot->vscroll), &alloc);  
 #ifdef SZBUG
           fprintf(stderr, "shoes_app_gtk_configure_menu %d, %d, %d, %d\n", 
               evt->configure.x, evt->configure.y, evt->configure.width, evt->configure.height);
           fprintf(stderr, "cfg alloc: %d %d %d %d\n\n", alloc.x, alloc.y, alloc.width, alloc.height);
 #endif
-          gtk_fixed_move(GTK_FIXED(canvas->slot->oscanvas), canvas->slot->vscroll,
-                         evt->configure.width - alloc.width, 0);
+          gtk_fixed_move(GTK_FIXED(canvas->slot->oscanvas), GTK_WIDGET(canvas->slot->vscroll), evt->configure.width - alloc.width, 0);
           gtk_adjustment_set_page_size(adj, evt->configure.height);
           gtk_adjustment_set_page_increment(adj, evt->configure.height - 32);
   
@@ -2271,6 +2286,7 @@ gboolean shoes_app_gtk_configure_menu(GtkWidget *widget, GdkEvent *evt, gpointer
   }
   app->width = evt->configure.width;
   app->height = evt->configure.height;
+
   return FALSE;
 }
 
@@ -2286,10 +2302,12 @@ void shoes_slot_init_menu(VALUE c, SHOES_SLOT_OS *parent, int x, int y, int widt
      problems with slot height being always tied to inside widgets cumulative heights
      creating heights overflow with no scrollbar !
   */
-  if (toplevel)
-    slot->oscanvas = canvas->app->os.shoes_window; // created in app_open
-  else
-    slot->oscanvas = gtkfixed_alt_new(width, height);
+  if (toplevel) {
+      slot->oscanvas = canvas->app->os.shoes_window; // created in app_open
+  }
+  else {
+      slot->oscanvas = gtkfixed_alt_new(width, height);
+  }
 #ifdef SZBUG
   fprintf(stderr,"shoes_slot_init_menu toplevel: %d, slot->oscanvas %lx\n", toplevel, (unsigned long)slot->oscanvas); 
 #endif
@@ -2303,7 +2321,7 @@ void shoes_slot_init_menu(VALUE c, SHOES_SLOT_OS *parent, int x, int y, int widt
   if (toplevel) {
     //gtk_container_add(GTK_CONTAINER(parent->oscanvas), slot->oscanvas);
   } else {
-    gtk_fixed_put(GTK_FIXED(parent->oscanvas), slot->oscanvas, x, y);
+    gtk_fixed_put(GTK_FIXED(parent->oscanvas), GTK_WIDGET(slot->oscanvas), x, y);
   }
   slot->scrollh = slot->scrollw = 0;
   slot->vscroll = NULL;
@@ -2317,9 +2335,10 @@ void shoes_slot_init_menu(VALUE c, SHOES_SLOT_OS *parent, int x, int y, int widt
 
     g_signal_connect(G_OBJECT(slot->vscroll), "value-changed",
                      G_CALLBACK(shoes_canvas_gtk_scroll), (gpointer)c);
-    gtk_fixed_put(GTK_FIXED(slot->oscanvas), slot->vscroll, -100, -100);
+   
+    gtk_fixed_put(GTK_FIXED(slot->oscanvas), GTK_WIDGET(slot->vscroll), -100, -100);
 
-    gtk_widget_set_size_request(slot->oscanvas, width, height);
+    gtk_widget_set_size_request(GTK_WIDGET(slot->oscanvas), width, height);
     //gtk_widget_set_size_request(slot->oscanvas, canvas->app->minwidth, canvas->app->minheight);
 
     if (!toplevel) 
@@ -2329,7 +2348,7 @@ void shoes_slot_init_menu(VALUE c, SHOES_SLOT_OS *parent, int x, int y, int widt
   if (toplevel)
     shoes_canvas_size(c, width, height);
   else {
-    gtk_widget_show_all(slot->oscanvas);
+    gtk_widget_show_all(GTK_WIDGET(slot->oscanvas));
     canvas->width = 100;
     canvas->height = 100;
   }
@@ -2385,11 +2404,11 @@ shoes_code shoes_native_app_open_menu(shoes_app *app, char *path, int dialog, sh
     }
 
     vbox =  gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-    gtk_container_add(GTK_CONTAINER(window), vbox);
-    gtk_box_pack_start(GTK_BOX(vbox), menubar, FALSE, FALSE, 0);
+    gtk_container_add(GTK_CONTAINER(window), GTK_WIDGET(vbox));
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(menubar), FALSE, FALSE, 0);
     // Gtk Container of the fixed variety. Note the alt version!!
     shoes_window = gtkfixed_alt_new(app->width, app->height); 
-    gtk_box_pack_start(GTK_BOX(vbox), shoes_window, FALSE, FALSE, 0);
+    gtk_box_pack_start(GTK_BOX(vbox), GTK_WIDGET(shoes_window), FALSE, FALSE, 0);
     
     gk->window = window;
     gk->vlayout = vbox;
@@ -2398,7 +2417,7 @@ shoes_code shoes_native_app_open_menu(shoes_app *app, char *path, int dialog, sh
 #ifdef SZBUG
     fprintf(stderr,"shoes_native_app_open slot->canvas %lx\n", (unsigned long)app->slot->oscanvas);
 #endif
-    app->mb_height = 26;  // TODO adhoc (a guess)
+    //app->mb_height = 26;  // TODO adhoc (a guess)
 
     // now we can add the default Shoes menus
     VALUE mbv = shoes_native_menubar_setup(app, menubar);
@@ -2414,13 +2433,15 @@ shoes_code shoes_native_app_open_menu(shoes_app *app, char *path, int dialog, sh
         GdkGeometry hints;
         hints.min_width = max(app->minwidth, 100);
         hints.min_height = max(app->minheight + app->mb_height, 100);
+
 #ifdef SZBUG
         fprintf(stderr,"resize hints: %d, %d\n", hints.min_width, hints.min_height);
 #endif
-        gtk_window_set_geometry_hints(GTK_WINDOW(window), NULL,
-                                      &hints, GDK_HINT_MIN_SIZE);
+
+        gtk_window_set_geometry_hints(GTK_WINDOW(window), NULL, &hints, GDK_HINT_MIN_SIZE);
         //gtk_window_set_resizable(GTK_WINDOW(window), TRUE); // no help with szbug
     }
+
     gtk_window_set_default_size(GTK_WINDOW(window), app->width, app->height + app->mb_height);
 
     gtk_window_get_position(GTK_WINDOW(window), &app->x, &app->y);
@@ -2448,7 +2469,9 @@ shoes_code shoes_native_app_open_menu(shoes_app *app, char *path, int dialog, sh
     g_signal_connect(G_OBJECT(window), "configure-event",   // bug #349
                      G_CALLBACK(shoes_app_gtk_configure_menu), app);
        
-    if (app->fullscreen) shoes_native_app_fullscreen(app, 1);
+    if (app->fullscreen) {
+        shoes_native_app_fullscreen(app, 1);
+    }
 
     gtk_window_set_decorated(GTK_WINDOW(window), app->decorated);
 #if GTK_CHECK_VERSION(3,8,0)

--- a/shoes/native/gtk.c
+++ b/shoes/native/gtk.c
@@ -515,10 +515,10 @@ void shoes_native_slot_lengthen(SHOES_SLOT_OS *slot, int height, int endy) {
             gtk_range_set_range(GTK_RANGE(slot->vscroll), 0., (gdouble)endy);
 
             if (gtk_adjustment_get_page_size(adj) >= gtk_adjustment_get_upper(adj)) {
-                gtk_widget_hide(slot->vscroll);
+                gtk_widget_hide(GTK_WIDGET(slot->vscroll));
             }
             else {
-                gtk_widget_show(slot->vscroll);
+                gtk_widget_show(GTK_WIDGET(slot->vscroll));
             }
         }
     }
@@ -533,7 +533,7 @@ void shoes_native_slot_scroll_top(SHOES_SLOT_OS *slot) {
 int shoes_native_slot_gutter(SHOES_SLOT_OS *slot) {
     if (slot->vscroll) {
         GtkRequisition rnat;
-        gtk_widget_get_preferred_size(slot->vscroll, NULL, &rnat);
+        gtk_widget_get_preferred_size(GTK_WIDGET(slot->vscroll), NULL, &rnat);
         return rnat.width;
     }
 
@@ -555,10 +555,15 @@ static gboolean shoes_app_gtk_motion(GtkWidget *widget, GdkEventMotion *event, g
         Data_Get_Struct(app->canvas, shoes_canvas, canvas);
         state = (GdkModifierType)event->state;
         int mods = 0;
-        if (event->state & GDK_SHIFT_MASK)
+        
+        if (event->state & GDK_SHIFT_MASK) {
           mods = mods | SHOES_MODIFY_SHIFT;
-        if (event->state & GDK_CONTROL_MASK)
+        }
+        
+        if (event->state & GDK_CONTROL_MASK) {
           mods = mods | SHOES_MODIFY_CTRL;
+        }
+
         int new_x, new_y;
         gtk_widget_translate_coordinates(widget, app->slot->oscanvas, event->x, event->y, &new_x, &new_y);
        if (app->have_menu) {
@@ -637,9 +642,9 @@ static gboolean shoes_app_gtk_button(GtkWidget *widget, GdkEventButton *event, g
     } else if (event->type == GDK_BUTTON_RELEASE) {
       if (app->have_menu) {
         shoes_app_release(app, event->button, new_x, new_y + canvas->slot->scrolly, mods);
-      } else
+      } else {
         shoes_app_release(app, event->button, new_x, new_y + canvas->slot->scrolly, mods);
-        //shoes_app_release(app, event->button, event->x, event->y + canvas->slot->scrolly, mods);
+      }
     }
     return TRUE;
 }
@@ -668,15 +673,17 @@ static gboolean shoes_app_gtk_wheel(GtkWidget *widget, GdkEventScroll *event, gp
     }
     // process modifiers
     int mods = 0;
-    if (event->state & GDK_SHIFT_MASK)
+    if (event->state & GDK_SHIFT_MASK) {
       mods = mods | SHOES_MODIFY_SHIFT;
+    }
     if (event->state & GDK_CONTROL_MASK)
       mods = mods | SHOES_MODIFY_CTRL; 
  		int new_x, new_y;
 		gtk_widget_translate_coordinates(widget, app->slot->oscanvas, event->x, event->y,
 			&new_x, &new_y);
-    if (app->have_menu) 
+    if (app->have_menu) {
       shoes_app_wheel(app, wheel, event->x, event->y - app->mb_height, mods);
+    }
     else {
       if (shoes_gtk_backend & WAYLAND) {
         new_y = max(0,new_y - 60);
@@ -766,13 +773,16 @@ static gboolean shoes_app_gtk_keypress(GtkWidget *widget, GdkEventKey *event, gp
             chbuf[len] = '\0';
 
             v = ID2SYM(rb_intern(chbuf));
-            if (modifiers & GDK_SHIFT_MASK)
+            if (modifiers & GDK_SHIFT_MASK) {
               modifiers ^= GDK_SHIFT_MASK;
+            }
         } else {
-            if (event->string[0] == '\r' && event->length == 1)
+            if (event->string[0] == '\r' && event->length == 1) {
                 v = rb_str_new2("\n");
-            else
+            }
+            else {
                 v = rb_str_new(event->string, event->length);
+            }
         }
     }
     KEY_SYM(Insert, insert);
@@ -809,12 +819,15 @@ static gboolean shoes_app_gtk_keypress(GtkWidget *widget, GdkEventKey *event, gp
                     v = ID2SYM(rb_intern("enter"));
 
             if (SYMBOL_P(v)) {
-                if (modifiers & GDK_MOD1_MASK)
+                if (modifiers & GDK_MOD1_MASK) {
                     KEY_STATE(alt);
-                if (modifiers & GDK_SHIFT_MASK)
+                }
+                if (modifiers & GDK_SHIFT_MASK) {
                     KEY_STATE(shift);
-                if (modifiers & GDK_CONTROL_MASK)
+                }
+                if (modifiers & GDK_CONTROL_MASK) {
                     KEY_STATE(control);
+                }
             }
 
             shoes_app_keypress(app, v);
@@ -828,8 +841,10 @@ static gboolean shoes_app_gtk_keypress(GtkWidget *widget, GdkEventKey *event, gp
 
 static gboolean shoes_app_gtk_quit(GtkWidget *widget, GdkEvent *event, gpointer data) {
     shoes_app *app = (shoes_app *)data;
-    if (shoes_app_remove(app))
+    if (shoes_app_remove(app)) {
         gtk_main_quit();
+    }
+
     return FALSE;
 }
 
@@ -866,16 +881,17 @@ static void shoes_canvas_gtk_size(GtkWidget *widget, GtkAllocation *size, gpoint
     if (canvas->slot->vscroll &&
             (size->height != canvas->slot->scrollh || size->width != canvas->slot->scrollw)) {
         GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(canvas->slot->vscroll));
-        gtk_widget_set_size_request(canvas->slot->vscroll, -1, size->height);
+        gtk_widget_set_size_request(GTK_WIDGET(canvas->slot->vscroll), -1, size->height);
         
         //gtk_widget_set_size_request(GTK_CONTAINER(widget), canvas->app->width, size->height);
         GtkAllocation alloc;
-        gtk_widget_get_allocation((GtkWidget *)canvas->slot->vscroll, &alloc);  
+        gtk_widget_get_allocation(GTK_WIDGET(canvas->slot->vscroll), &alloc);  
 #ifdef SZBUG
         fprintf(stderr, "alloc: %d %d %d %d\n\n", alloc.x, alloc.y, alloc.width, alloc.height);
 #endif
-        if (canvas->slot->oscanvas != widget) 
+        if (canvas->slot->oscanvas != widget) {
           fprintf(stderr,"shoes_canvas_gtk_size: ooops\n");
+        }
           
         gtk_fixed_move(GTK_FIXED(canvas->slot->oscanvas), canvas->slot->vscroll,
                        size->width - alloc.width, 0);
@@ -926,17 +942,21 @@ static gint shoes_app_g_poll(GPollFD *fds, guint nfds, gint timeout) {
 
     for (f = fds; f < &fds[nfds]; ++f)
         if (f->fd >= 0) {
-            if (f->events & G_IO_IN)
+            if (f->events & G_IO_IN) {
                 //FD_SET (f->fd, &rset);
                 rb_fd_set(f->fd, &rset);
-            if (f->events & G_IO_OUT)
+            }
+            if (f->events & G_IO_OUT) {
                 //FD_SET (f->fd, &wset);
                 rb_fd_set(f->fd, &wset);
-            if (f->events & G_IO_PRI)
+            }
+            if (f->events & G_IO_PRI) {
                 //FD_SET (f->fd, &xset);
                 rb_fd_set(f->fd, &xset);
-            if (f->fd > maxfd && (f->events & (G_IO_IN|G_IO_OUT|G_IO_PRI)))
+            }
+            if (f->fd > maxfd && (f->events & (G_IO_IN|G_IO_OUT|G_IO_PRI))) {
                 maxfd = f->fd;
+            }
         }
 
     //
@@ -958,14 +978,17 @@ static gint shoes_app_g_poll(GPollFD *fds, guint nfds, gint timeout) {
             f->revents = 0;
             if (f->fd >= 0) {
                 //if (FD_ISSET (f->fd, &rset))
-                if (rb_fd_isset (f->fd, &rset))
+                if (rb_fd_isset (f->fd, &rset)) {
                     f->revents |= G_IO_IN;
+                }
                 //if (FD_ISSET (f->fd, &wset))
-                if (rb_fd_isset (f->fd, &wset))
+                if (rb_fd_isset (f->fd, &wset)) {
                     f->revents |= G_IO_OUT;
+                }
                 //if (FD_ISSET (f->fd, &xset))
-                if (rb_fd_isset (f->fd, &xset))
+                if (rb_fd_isset (f->fd, &xset)) {
                     f->revents |= G_IO_PRI;
+                }
             }
         }
     // Free the allocated storage from rb_fd_init
@@ -1001,14 +1024,18 @@ static gint shoes_app_g_poll(GPollFD *fds, guint nfds, gint timeout) {
     for (i = 0; i < nfds; i++) {
         f = &fds[i];
         if (f->fd >= 0) {
-            if (f->events & G_IO_IN)
+            if (f->events & G_IO_IN) {
                 FD_SET(f->fd, &rset);
-            if (f->events & G_IO_OUT)
+            }
+            if (f->events & G_IO_OUT) {
                 FD_SET(f->fd, &wset);
-            if (f->events & G_IO_PRI)
+            }
+            if (f->events & G_IO_PRI) {
                 FD_SET(f->fd, &xset);
-            if (f->fd > maxfd && (f->events & (G_IO_IN|G_IO_OUT|G_IO_PRI)))
+            }
+            if (f->fd > maxfd && (f->events & (G_IO_IN|G_IO_OUT|G_IO_PRI))) {
                 maxfd = max (maxfd, i+1);
+            }
         }
     }
     //
@@ -1019,8 +1046,9 @@ static gint shoes_app_g_poll(GPollFD *fds, guint nfds, gint timeout) {
     // keep it from completely blocking the GUI. 
     //
     // WARNING timeout can be (is) 0 on Windows and Linux
-    if (timeout == -1 || timeout > 500)
+    if (timeout == -1 || timeout > 500) {
         timeout = 500;
+    }
 
     tv.tv_sec = timeout / 1000;
     tv.tv_usec = (timeout % 1000) * 1000;
@@ -1035,12 +1063,15 @@ static gint shoes_app_g_poll(GPollFD *fds, guint nfds, gint timeout) {
         for (f = fds; f < &fds[nfds]; ++f) {
             f->revents = 0;
             if (f->fd >= 0) {
-                if (FD_ISSET (f->fd, &rset))
+                if (FD_ISSET (f->fd, &rset)) {
                     f->revents |= G_IO_IN;
-                if (FD_ISSET (f->fd, &wset))
+                }
+                if (FD_ISSET (f->fd, &wset)) {
                     f->revents |= G_IO_OUT;
-                if (FD_ISSET (f->fd, &xset))
+                }
+                if (FD_ISSET (f->fd, &xset)) {
                     f->revents |= G_IO_PRI;
+                }
             }
         }
     }
@@ -1105,7 +1136,9 @@ void shoes_native_loop() {
 #endif
 #endif
     GLOBAL_APP(app);
-    if (APP_WINDOW(app)) gtk_main();
+    if (APP_WINDOW(app)) {
+         gtk_main();
+    }
 }
 
 shoes_code shoes_app_cursor(shoes_app *app, ID cursor) {
@@ -1137,8 +1170,9 @@ shoes_code shoes_app_cursor(shoes_app *app, ID cursor) {
           c = gdk_cursor_new(GDK_XTERM);
       } else if (cursor == s_watch_cursor) {
           c = gdk_cursor_new(GDK_WATCH);
-      } else
+      } else {
           goto done;
+      }
 #pragma GCC diagnostic pop
     }
     gdk_window_set_cursor(gtk_widget_get_window(app->os.window), c);
@@ -1155,7 +1189,6 @@ void shoes_native_app_title(shoes_app *app, char *msg) {
 void shoes_native_app_resize_window(shoes_app *app) {
     if ((app->os.window != NULL) && (app->width > 0 && app->height > 0)) {
         gtk_window_resize(GTK_WINDOW(app->os.window), app->width, app->height );
-        //gtk_widget_set_size_request((GtkWidget *) app->os.window, app->width, app->height);
     }
 }
 
@@ -1273,10 +1306,10 @@ gboolean shoes_app_gtk_configure_event(GtkWidget *widget, GdkEvent *evt, gpointe
 #endif
     //if (canvas->slot->vscroll && evt->configure.height != app->height) { 
           GtkAdjustment *adj = gtk_range_get_adjustment(GTK_RANGE(canvas->slot->vscroll));
-          gtk_widget_set_size_request(canvas->slot->vscroll, -1, evt->configure.height);
+          gtk_widget_set_size_request(GTK_WIDGET(canvas->slot->vscroll), -1, evt->configure.height);
           
           GtkAllocation alloc;
-          gtk_widget_get_allocation((GtkWidget *)canvas->slot->vscroll, &alloc);  
+          gtk_widget_get_allocation(GTK_WIDGET(canvas->slot->vscroll), &alloc);  
 #ifdef SZBUG
           fprintf(stderr, "shoes_app_gtk_configure_menu %d, %d, %d, %d\n", 
               evt->configure.x, evt->configure.y, evt->configure.width, evt->configure.height);
@@ -1313,11 +1346,14 @@ shoes_code shoes_native_app_open(shoes_app *app, char *path, int dialog, shoes_s
       sprintf(icon_path, "%s/static/app-icon.png", shoes_world->path);
     else {
       char *ip = RSTRING_PTR(st->icon_path);
-      if (*ip == '/' || ip[1] ==':')  
+      if (*ip == '/' || ip[1] ==':') {
         strcpy(icon_path, ip);
-      else
+      }
+      else {
        sprintf(icon_path, "%s/%s", shoes_world->path, ip);
+      }
     }
+
     gtk_window_set_default_icon_from_file(icon_path, NULL);
 
     // The Good old way, menu-less
@@ -1454,14 +1490,16 @@ void shoes_slot_init(VALUE c, SHOES_SLOT_OS *parent, int x, int y, int width, in
                          G_CALLBACK(shoes_canvas_gtk_scroll), (gpointer)c);
         gtk_fixed_put(GTK_FIXED(slot->oscanvas), slot->vscroll, -100, -100);
 
-        gtk_widget_set_size_request(slot->oscanvas, width, height);
-        //gtk_widget_set_size_request(slot->oscanvas, canvas->app->minwidth, canvas->app->minheight);
+        gtk_widget_set_size_request(GTK_WIDGET(slot->oscanvas), width, height);
 
-        if (!toplevel) ATTRSET(canvas->attr, wheel, scrolls);
+        if (!toplevel) { 
+            ATTRSET(canvas->attr, wheel, scrolls);
+        }
     }
 
-    if (toplevel)
+    if (toplevel) {
         shoes_canvas_size(c, width, height);
+    }
     else {
         gtk_widget_show_all(slot->oscanvas);
         canvas->width = 100;
@@ -1470,8 +1508,10 @@ void shoes_slot_init(VALUE c, SHOES_SLOT_OS *parent, int x, int y, int width, in
 }
 
 void shoes_slot_destroy(shoes_canvas *canvas, shoes_canvas *pc) {
-    if (canvas->slot->vscroll)
+    if (canvas->slot->vscroll) {
         gtk_container_remove(GTK_CONTAINER(canvas->slot->oscanvas), canvas->slot->vscroll);
+    }
+
     gtk_container_remove(GTK_CONTAINER(pc->slot->oscanvas), canvas->slot->oscanvas);
 }
 
@@ -1599,8 +1639,9 @@ void shoes_native_control_focus(SHOES_CONTROL_REF ref) {
 
 void shoes_native_control_state(SHOES_CONTROL_REF ref, gboolean sensitive, gboolean setting) {
     gtk_widget_set_sensitive(ref, sensitive);
-    if (GTK_IS_EDITABLE(ref))
+    if (GTK_IS_EDITABLE(ref)) {
         gtk_editable_set_editable(GTK_EDITABLE(ref), setting);
+    }
     else if (GTK_IS_SCROLLED_WINDOW(ref)) {
         GtkWidget *textview;
         GTK_CHILD(textview, ref);
@@ -1719,12 +1760,13 @@ VALUE shoes_dialog_alert(int argc, VALUE *argv, VALUE self) {
 
     // theme the window
     if (shoes_css_provider != NULL) {
-      gtk_style_context_add_provider(gtk_widget_get_style_context(dialog),
+      gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(dialog)),
           GTK_STYLE_PROVIDER(shoes_css_provider),
           GTK_STYLE_PROVIDER_PRIORITY_USER);
     }
     gtk_dialog_run(GTK_DIALOG(dialog));
-    gtk_widget_destroy(dialog);
+
+    gtk_widget_destroy(GTK_WIDGET(dialog));
     return Qnil;
 }
 
@@ -1755,7 +1797,7 @@ VALUE shoes_dialog_ask(int argc, VALUE *argv, VALUE self) {
 
     // theme the window
     if (shoes_css_provider != NULL) {
-      gtk_style_context_add_provider(gtk_widget_get_style_context(dialog),
+      gtk_style_context_add_provider(gtk_widget_get_style_context(GTK_WIDGET(dialog)),
           GTK_STYLE_PROVIDER(shoes_css_provider),
           GTK_STYLE_PROVIDER_PRIORITY_USER);
     }
@@ -1807,8 +1849,6 @@ VALUE shoes_dialog_confirm(int argc, VALUE *argv, VALUE self) {
             }
             break;
     }
-
-
 
     GtkWidget *dialog = gtk_dialog_new_with_buttons(atitle, window_app, GTK_DIALOG_MODAL,
                         _("_Cancel"), GTK_RESPONSE_CANCEL, _("_OK"), GTK_RESPONSE_OK, NULL);

--- a/shoes/types/menubar.c
+++ b/shoes/types/menubar.c
@@ -90,8 +90,10 @@ VALUE shoes_menubar_index(VALUE self, VALUE arg) {
   if (TYPE(arg) == T_FIXNUM) {
     int pos = NUM2INT(arg);
     int cnt = RARRAY_LEN(mb->menus);
-    if (pos < cnt && pos >= 0)
+    if (pos < cnt && pos >= 0) {
       return arg;
+
+    }
   } else if (TYPE(arg) == T_STRING) {
     char *txt = RSTRING_PTR(arg);
     int cnt = RARRAY_LEN(mb->menus);
@@ -111,8 +113,9 @@ VALUE shoes_menubar_index(VALUE self, VALUE arg) {
 }
 VALUE shoes_menubar_at(VALUE self, VALUE arg) {
   VALUE posv = shoes_menubar_index(self, arg);
-  if (NIL_P(posv))
+  if (NIL_P(posv)) {
     return posv;
+  }
   shoes_menubar *mb;
   Data_Get_Struct(self, shoes_menubar, mb);
   int pos = NUM2INT(posv);
@@ -128,9 +131,13 @@ VALUE shoes_menubar_at(VALUE self, VALUE arg) {
       VALUE mnv = rb_ary_entry(mb->menus, i);
       shoes_menu *mn;
       Data_Get_Struct(mnv, shoes_menu, mn);
-      if (mn->title == 0) continue;
-      if (strcmp(txt,mn->title) == 0)
-        return mnv;    
+      if (mn->title == 0) {
+        continue;
+      }
+
+      if (strcmp(txt,mn->title) == 0) {
+        return mnv
+      }
     }
   } else
     rb_raise(rb_eArgError, "index must be string or integer");
@@ -144,10 +151,12 @@ VALUE shoes_menubar_insert(VALUE self, VALUE mnv, VALUE arg) {
   Data_Get_Struct(self, shoes_menubar, mb);
   int cnt = RARRAY_LEN(mb->menus);  //cnt before
   VALUE pv = shoes_menubar_index(self, arg);
-  if (NIL_P(pv))
+  if (NIL_P(pv)) {
     pos = -1;
-  else
+  }
+  else {
     pos = NUM2INT(pv);
+  }
   // if pos is < 0 we can call append and return 
   if (pos < 0) {
     shoes_menubar_append(self, mnv);
@@ -183,11 +192,13 @@ VALUE shoes_menubar_remove(VALUE self, VALUE arg) {
   shoes_menubar *mb;
   Data_Get_Struct(self, shoes_menubar, mb);
   VALUE posv = shoes_menubar_index(self, arg);
-  if (NIL_P(posv))
+  if (NIL_P(posv)) {
     rb_raise(rb_eArgError, "menu not found");
+  }
   int pos = NUM2INT(posv);
-  if (pos == 0)
-    return Qnil;        // can't delete Shoes menu
+  if (pos == 0) {
+    return Qnil;
+  }
   // remove the native
   shoes_native_menubar_remove(mb, pos); 
   // include/ruby/intern.h has

--- a/startup.yaml
+++ b/startup.yaml
@@ -1,4 +1,4 @@
-App_Name: Foobar
+App_Name: Shoes
 #Icon_Path: static/shoes-icon-blue.png
 #Theme: XP 
 #Display_Backend: wayland


### PR DESCRIPTION
Okay this time I've really fixed the issue resize issue. I've also added GTK macro type checks when calling the UI functions from the GTK API with widgets.

So according to the GTK docs: 
_Unlike gtk_widget_set_size_request(), which sets a size request for a widget and thus would keep users from shrinking the window, this function only sets the initial size, just as if the user had resized the window themselves. Users can still shrink the window again as they normally would. Setting a default size of -1 means to use the “natural” default size (the size request of the window)._


there were two main issues I found:
1. sometimes the `widget` was null  
2. I updated the width to be -1 value based on comment above in the gtk docs and sure enough all the nasty errors went away and window was resizing properly. also vertical bar issue was fixed by this as well.

again more clean up in `gtk.c`. Anyhow my goal currently is to get the master branch as stable as possible in its current state. I'm working on updating gtk to properly cast the correct types when calling ui functions, clean up errors in other source files. stay tuned!